### PR TITLE
fix: avoid `nonces` in development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
 	"editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
-	"editor.rulers": [80],
 	"eslint.probe": [
 		"javascript",
 		"javascriptreact",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,7 @@ export default tseslint.config(
 			"@typescript-eslint/no-unsafe-call": "off",
 			"@typescript-eslint/no-unsafe-argument": "off",
 			"@typescript-eslint/no-unnecessary-type-assertion": "off",
+			"no-extra-boolean-cast": "off",
 
 			// These on-by-default rules don't work well for this repo and we like them off.
 			"no-constant-condition": "off",

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -50,7 +50,8 @@ export const addNonceToDirectives = (
 };
 
 export function generateCSP(cspOptions: CSP["value"], nonceString?: string) {
-  const directives = nonceString ? addNonceToDirectives(cspOptions, nonceString) : cspOptions;
+  const isDev = process.env.NODE_ENV === "development";
+  const directives = nonceString && !isDev ? addNonceToDirectives(cspOptions, nonceString) : cspOptions;
 
   if (Object.prototype.hasOwnProperty.call(directives,"report-uri")) {
     const reportUri = directives["report-uri"];


### PR DESCRIPTION
- **chore: remove ruler from VSCode settings**
- **fix: avoid `nonce` in dev mode**

While in development, it's necessary to have inline styles and scripts. CSPs don't allow `UNSAVE_INLINE` in the same directive as a `nonce`
