### PR TITLE
fix: add `UNSAFE_INLINE` to Dev CSP - `script-src`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 .all-contributorsrc
 .husky/
 coverage/
-lib/
+dist/
 pnpm-lock.yaml

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,4 +1,4 @@
-import { SELF, UNSAFE_EVAL, UNSAFE_INLINE } from "csp-header";
+import { NONE, SELF, UNSAFE_EVAL, UNSAFE_INLINE } from "csp-header";
 import { CSP, type HeaderNames } from "./types.js";
 
 export const PROD_DEFAULT_CSP: CSP["value"] = {
@@ -15,12 +15,12 @@ export const PROD_DEFAULT_CSP: CSP["value"] = {
 export const DEV_DEFAULT_CSP: CSP["value"] = {
 	"default-src": [SELF],
 	"frame-src": [SELF],
-	"script-src": [SELF, UNSAFE_EVAL],
+	"script-src": [SELF, UNSAFE_EVAL, UNSAFE_INLINE],
 	"style-src": [SELF],
 	"style-src-elem": [SELF, UNSAFE_INLINE],
 	"connect-src": [SELF, "ws://localhost:*"],
 	"img-src": [SELF],
-	"object-src": [],
+	"object-src": [NONE],
 };
 
 export const HEADER_NAMES: HeaderNames = {

--- a/src/lib/permissions-policy.ts
+++ b/src/lib/permissions-policy.ts
@@ -1,20 +1,18 @@
 interface HardwarePermissions {
-  camera?: string;
-  microphone?: string;
-  geolocation?: string;
-  payment?: string;
+	camera?: string;
+	microphone?: string;
+	geolocation?: string;
+	payment?: string;
 }
 
 export function permissionsPolicy(perms: HardwarePermissions) {
-  const headerValue: string[] = [];
+	const headerValue: string[] = [];
 
-  for (const [key, value] of Object.entries(perms)) {
-    if (typeof value === "string") {
-      headerValue.push(`${key}=${value}`);
-    }
-  }
+	for (const [key, value] of Object.entries(perms)) {
+		if (typeof value === "string") {
+			headerValue.push(`${key}=${value}`);
+		}
+	}
 
-  // headerValue = ["camera=()", "microphone=()"]
-  return headerValue.join(", ");
-  // "camera=(), microfone=()"
+	return headerValue.join(", ");
 }


### PR DESCRIPTION
While in development it's needed to be able to use `UNSAFE_INLINE` for Hot Module Replacement